### PR TITLE
[Feat] planUnit별 기록 조회 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/record/application/dto/result/FeedListResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/dto/result/FeedListResult.java
@@ -1,0 +1,17 @@
+package com.yeoljeong.tripmate.record.application.dto.result;
+
+import com.yeoljeong.tripmate.record.domain.model.Feed;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record FeedListResult(
+    List<FeedDetailResult> results
+) {
+
+  public static FeedListResult from(List<Feed> feeds) {
+    return FeedListResult.builder()
+        .results(feeds.stream().map(FeedDetailResult::from).toList())
+        .build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/command/RecordCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/command/RecordCommandService.java
@@ -1,13 +1,13 @@
-package com.yeoljeong.tripmate.record.service.command;
+package com.yeoljeong.tripmate.record.application.service.command;
 
 import com.yeoljeong.tripmate.record.application.dto.command.FeedCreateCommand;
 import com.yeoljeong.tripmate.record.application.dto.command.FeedVisibilityCommand;
 import com.yeoljeong.tripmate.record.application.dto.result.FeedBaseResult;
-import com.yeoljeong.tripmate.record.application.dto.result.FeedCreateResult;
+import com.yeoljeong.tripmate.record.application.dto.result.FeedDetailResult;
 
 public interface RecordCommandService {
 
-  FeedCreateResult createFeedImage(FeedCreateCommand command);
+  FeedDetailResult createFeedImage(FeedCreateCommand command);
 
   FeedBaseResult updateFeedVisibility(FeedVisibilityCommand command);
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/command/impl/RecordCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/command/impl/RecordCommandServiceImpl.java
@@ -1,16 +1,16 @@
-package com.yeoljeong.tripmate.record.service.command.impl;
+package com.yeoljeong.tripmate.record.application.service.command.impl;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.record.application.client.StorageClient;
 import com.yeoljeong.tripmate.record.application.dto.command.FeedCreateCommand;
 import com.yeoljeong.tripmate.record.application.dto.command.FeedVisibilityCommand;
 import com.yeoljeong.tripmate.record.application.dto.result.FeedBaseResult;
-import com.yeoljeong.tripmate.record.application.dto.result.FeedCreateResult;
+import com.yeoljeong.tripmate.record.application.dto.result.FeedDetailResult;
+import com.yeoljeong.tripmate.record.application.service.command.RecordCommandService;
 import com.yeoljeong.tripmate.record.domain.exception.RecordErrorCode;
 import com.yeoljeong.tripmate.record.domain.model.Feed;
 import com.yeoljeong.tripmate.record.domain.model.FeedImage;
 import com.yeoljeong.tripmate.record.domain.repository.RecordRepository;
-import com.yeoljeong.tripmate.record.service.command.RecordCommandService;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -31,7 +31,7 @@ public class RecordCommandServiceImpl implements RecordCommandService {
   }
 
   @Transactional
-  public FeedCreateResult createFeedImage(FeedCreateCommand command) {
+  public FeedDetailResult createFeedImage(FeedCreateCommand command) {
     Feed feed = Feed.create(
         command.userId(),
         command.planUnitId(),
@@ -46,7 +46,7 @@ public class RecordCommandServiceImpl implements RecordCommandService {
       } catch (Exception ignored) {
       }
     }
-    return FeedCreateResult.from(recordRepository.saveForFeed(feed));
+    return FeedDetailResult.from(recordRepository.saveForFeed(feed));
   }
 
   @Override

--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/query/RecordQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/query/RecordQueryService.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.record.application.service.query;
+
+import com.yeoljeong.tripmate.record.application.dto.result.FeedListResult;
+import java.util.UUID;
+
+public interface RecordQueryService {
+
+  FeedListResult getFeedListDataByPlan(UUID uuid, UUID planUnitId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/query/impl/RecordQueryServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/query/impl/RecordQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.yeoljeong.tripmate.record.application.service.query.impl;
+
+import com.yeoljeong.tripmate.record.application.dto.result.FeedListResult;
+import com.yeoljeong.tripmate.record.application.service.query.RecordQueryService;
+import com.yeoljeong.tripmate.record.domain.repository.RecordRepository;
+import com.yeoljeong.tripmate.record.infrastructure.external.PlanAdapter;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecordQueryServiceImpl implements RecordQueryService {
+
+  private final PlanAdapter planAdapter;
+  private final RecordRepository recordRepository;
+
+  @Override
+  public FeedListResult getFeedListDataByPlan(UUID userId, UUID planUnitId) {
+    boolean isPlanUnitMember = planAdapter.validateGroupMember(userId, planUnitId);
+    return FeedListResult.from(
+        recordRepository.findFeedListByCondition(userId, planUnitId, isPlanUnitMember));
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/query/impl/RecordQueryServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/query/impl/RecordQueryServiceImpl.java
@@ -16,6 +16,7 @@ public class RecordQueryServiceImpl implements RecordQueryService {
   private final RecordRepository recordRepository;
 
   @Override
+  @Transactional(readOnly = true)
   public FeedListResult getFeedListDataByPlan(UUID userId, UUID planUnitId) {
     boolean isPlanUnitMember = planAdapter.validateGroupMember(userId, planUnitId);
     return FeedListResult.from(

--- a/src/main/java/com/yeoljeong/tripmate/record/domain/repository/RecordRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/domain/repository/RecordRepository.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.record.domain.repository;
 
 import com.yeoljeong.tripmate.record.domain.model.Feed;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -9,4 +10,6 @@ public interface RecordRepository {
   Feed saveForFeed(Feed feed);
 
   Optional<Feed> findFeedDataById(UUID feedId);
+
+  List<Feed> findFeedListByCondition(UUID userId, UUID planUnitId, boolean isPlanUnitMember);
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/jpa/FeedJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/jpa/FeedJpaRepository.java
@@ -4,8 +4,10 @@ import com.yeoljeong.tripmate.record.domain.model.Feed;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface FeedJpaRepository extends JpaRepository<Feed, UUID> {
+public interface FeedJpaRepository extends JpaRepository<Feed, UUID>,
+    JpaSpecificationExecutor<Feed> {
 
   Optional<Feed> findByIdAndIsDeletedIsFalse(UUID feedId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/repositoryImpl/RecordRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/repositoryImpl/RecordRepositoryImpl.java
@@ -1,11 +1,17 @@
 package com.yeoljeong.tripmate.record.infrastructure.persistence.repositoryImpl;
 
+import com.yeoljeong.tripmate.record.domain.constants.VisibilityType;
 import com.yeoljeong.tripmate.record.domain.model.Feed;
 import com.yeoljeong.tripmate.record.domain.repository.RecordRepository;
 import com.yeoljeong.tripmate.record.infrastructure.persistence.jpa.FeedJpaRepository;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,5 +28,38 @@ public class RecordRepositoryImpl implements RecordRepository {
   @Override
   public Optional<Feed> findFeedDataById(UUID feedId) {
     return feedJpaRepository.findByIdAndIsDeletedIsFalse(feedId);
+  }
+
+  @Override
+  public List<Feed> findFeedListByCondition(UUID userId, UUID planUnitId,
+      boolean isPlanUnitMember) {
+    Specification<Feed> specification = (root, query, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      predicates.add(cb.equal(root.get("planUnitId"), planUnitId));
+
+      Path<VisibilityType> visibility = root.get("visibilityType");
+
+      Predicate publicFeed = cb.equal(visibility, VisibilityType.PUBLIC);
+
+      Predicate groupFeed = cb.and(
+          cb.equal(visibility, VisibilityType.GROUP),
+          cb.isTrue(cb.literal(isPlanUnitMember))
+      );
+
+      Predicate privateOwnFeed = cb.and(
+          cb.equal(visibility, VisibilityType.PRIVATE),
+          cb.equal(root.get("userId"), userId)
+      );
+
+      predicates.add(cb.or(
+          publicFeed,
+          groupFeed,
+          privateOwnFeed
+      ));
+
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+    return feedJpaRepository.findAll(specification);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/repositoryImpl/RecordRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/repositoryImpl/RecordRepositoryImpl.java
@@ -51,6 +51,7 @@ public class RecordRepositoryImpl implements RecordRepository {
           cb.equal(visibility, VisibilityType.PRIVATE),
           cb.equal(root.get("userId"), userId)
       );
+      predicates.add(cb.isFalse(root.get("isDeleted")));
 
       predicates.add(cb.or(
           publicFeed,

--- a/src/main/java/com/yeoljeong/tripmate/record/presentaion/controller/RecordController.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/presentaion/controller/RecordController.java
@@ -3,15 +3,18 @@ package com.yeoljeong.tripmate.record.presentaion.controller;
 import com.yeoljeong.tripmate.auth.annotation.LoginUser;
 import com.yeoljeong.tripmate.auth.context.UserContext;
 import com.yeoljeong.tripmate.record.application.service.command.RecordCommandService;
+import com.yeoljeong.tripmate.record.application.service.query.RecordQueryService;
 import com.yeoljeong.tripmate.record.presentaion.dto.request.FeedCreateRequest;
 import com.yeoljeong.tripmate.record.presentaion.dto.request.FeedVisibilityRequest;
 import com.yeoljeong.tripmate.record.presentaion.dto.response.FeedBaseResponse;
 import com.yeoljeong.tripmate.record.presentaion.dto.response.FeedDetailResponse;
+import com.yeoljeong.tripmate.record.presentaion.dto.response.FeedListResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecordController {
 
   private final RecordCommandService recordCommandService;
+  private final RecordQueryService recordQueryService;
 
   @PostMapping()
   public ApiResponse<FeedDetailResponse> createFeedData(
@@ -55,5 +59,20 @@ public class RecordController {
             )
         )
     );
+  }
+
+  @GetMapping("/{planUnitId}")
+  public ApiResponse<FeedListResponse> getFeedListDataByPlan(
+      @LoginUser UserContext userContext,
+      @PathVariable UUID planUnitId
+  ) {
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        FeedListResponse.from(
+            recordQueryService.getFeedListDataByPlan(
+                UUID.fromString(userContext.userId()),
+                planUnitId
+            )
+        ));
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/presentaion/dto/response/FeedListResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/presentaion/dto/response/FeedListResponse.java
@@ -1,0 +1,17 @@
+package com.yeoljeong.tripmate.record.presentaion.dto.response;
+
+import com.yeoljeong.tripmate.record.application.dto.result.FeedListResult;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record FeedListResponse(
+    List<FeedDetailResponse> responses
+
+) {
+
+  public static FeedListResponse from(FeedListResult result) {
+    return FeedListResponse.builder()
+        .responses(result.results().stream().map(FeedDetailResponse::from).toList()).build();
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- planUnit별로 기록들을 조회합니다.
- FeignClient 통신을 통해 접근권한을 확인합니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- JPA SpecificationExecutor 사용으로 동적 쿼리 작성
- 플랜 FeignClient 확인 완료
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 플랜 단위 피드 목록 조회 추가: 사용자의 권한과 피드 공개 범위에 따라 조회 가능한 피드만 반환합니다 (GET /feeds/{planUnitId}).
  * 피드 생성 응답 개선: 피드 업로드 시 상세 피드 정보를 바로 반환해 생성 결과를 즉시 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->