### PR TITLE
[Feat] 내 피드 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/query/RecordQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/query/RecordQueryService.java
@@ -5,5 +5,7 @@ import java.util.UUID;
 
 public interface RecordQueryService {
 
-  FeedListResult getFeedListDataByPlan(UUID uuid, UUID planUnitId);
+  FeedListResult getFeedListDataByPlan(UUID userId, UUID planUnitId);
+
+  FeedListResult getMyFeedList(UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/application/service/query/impl/RecordQueryServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/application/service/query/impl/RecordQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.yeoljeong.tripmate.record.infrastructure.external.PlanAdapter;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,5 +22,13 @@ public class RecordQueryServiceImpl implements RecordQueryService {
     boolean isPlanUnitMember = planAdapter.validateGroupMember(userId, planUnitId);
     return FeedListResult.from(
         recordRepository.findFeedListByCondition(userId, planUnitId, isPlanUnitMember));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public FeedListResult getMyFeedList(UUID userId) {
+    return FeedListResult.from(
+        recordRepository.findFeedListByUserId(userId)
+    );
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/domain/repository/RecordRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/domain/repository/RecordRepository.java
@@ -12,4 +12,6 @@ public interface RecordRepository {
   Optional<Feed> findFeedDataById(UUID feedId);
 
   List<Feed> findFeedListByCondition(UUID userId, UUID planUnitId, boolean isPlanUnitMember);
+
+  List<Feed> findFeedListByUserId(UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/jpa/FeedJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/jpa/FeedJpaRepository.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.record.infrastructure.persistence.jpa;
 
 import com.yeoljeong.tripmate.record.domain.model.Feed;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface FeedJpaRepository extends JpaRepository<Feed, UUID>,
     JpaSpecificationExecutor<Feed> {
 
   Optional<Feed> findByIdAndIsDeletedIsFalse(UUID feedId);
+
+  List<Feed> findAllByUserIdAndIsDeletedIsFalse(UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/repositoryImpl/RecordRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/infrastructure/persistence/repositoryImpl/RecordRepositoryImpl.java
@@ -63,4 +63,9 @@ public class RecordRepositoryImpl implements RecordRepository {
     };
     return feedJpaRepository.findAll(specification);
   }
+
+  @Override
+  public List<Feed> findFeedListByUserId(UUID userId) {
+    return feedJpaRepository.findAllByUserIdAndIsDeletedIsFalse(userId);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/record/presentaion/controller/RecordController.java
+++ b/src/main/java/com/yeoljeong/tripmate/record/presentaion/controller/RecordController.java
@@ -75,4 +75,18 @@ public class RecordController {
             )
         ));
   }
+
+  @GetMapping("/me")
+  public ApiResponse<FeedListResponse> getMyFeedList(
+      @LoginUser UserContext userContext
+  ) {
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        FeedListResponse.from(
+            recordQueryService.getMyFeedList(
+                UUID.fromString(userContext.userId())
+            )
+        )
+    );
+  }
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 내 피드 목록을 조회하는 API 구현

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 
- 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- 사용자가 자신의 여행 기록 피드 목록을 조회할 수 있는 새로운 기능이 추가되었습니다. 모든 여행 기록을 한 화면에서 쉽게 확인할 수 있으며, 삭제 처리된 기록은 자동으로 필터링되어 현재 활성화된 유효한 피드만 표시됩니다. 이를 통해 사용자는 개인의 여행 추억을 더욱 효율적으로 조회하고 관리할 수 있으며, 깔끔한 상태의 기록 목록을 유지할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->